### PR TITLE
Calarified address names

### DIFF
--- a/English-Version/addresses.csv
+++ b/English-Version/addresses.csv
@@ -1,3 +1,3 @@
-Milkyway,Auriga,Cetus,Centaurus,Cancer,Scutum,Eridanus
-Universe,G1,G2,G3,G4,G5,G6
-Pegasus,ROEHI,ONCE EL,BASELAI,SANDOVI,ILLUME,AMIWILL
+Milkyway Example,Auriga,Cetus,Centaurus,Cancer,Scutum,Eridanus
+Universe Example,G1,G2,G3,G4,G5,G6
+Pegasus Example,ROEHI,ONCE EL,BASELAI,SANDOVI,ILLUME,AMIWILL


### PR DESCRIPTION
clarified the names of addresses in the example addresses to make it more clear that they are names rather than the address type